### PR TITLE
use mongo aggregation sorting instead of sorting on the server itself

### DIFF
--- a/src/endpoints/Leaderboard/recent.js
+++ b/src/endpoints/Leaderboard/recent.js
@@ -1,0 +1,39 @@
+const leaderboard = require('../../utils/leaderboard');
+
+module.exports = {
+    path: `/leaderboard/recent`,
+    description: `Gets posted scores from a specific map hash`,
+    query: {
+        page: {
+            type: `integer`,
+            description: `Page of scores to get`,
+            required: false,
+            default: 1
+        },
+        limit: {
+            type: `integer`,
+            description: `Amount of scores to return. Max 50`,
+            values: Array.from(Array(50).keys()).map(a => a+1), // 1-50
+            required: false,
+            default: 10
+        },
+    },
+    get: async (req, res) => {
+        leaderboard.getRecent({ ...req.query }).then(data => {
+            res.send(data);
+        }).catch(e => {
+            const s = e.toString().toLowerCase().split(` `)
+
+            res.send(`yeah, no`)
+
+            //res.status(s.includes(`found`) ? 404 : 500).send({ error: e });
+        })
+    }
+}
+
+module.exports.get.tests = [
+    {
+        path: `/leaderboard/recent`,
+        description: `Successful leaderboard lookup`
+    },
+]

--- a/src/endpoints/Leaderboard/recent.js
+++ b/src/endpoints/Leaderboard/recent.js
@@ -17,6 +17,11 @@ module.exports = {
             required: false,
             default: 10
         },
+        id: {
+            type: `string`,
+            description: `User ID; used to get recent scores of a specific player`,
+            required: false,
+        },
     },
     get: async (req, res) => {
         leaderboard.getRecent({ ...req.query }).then(data => {
@@ -24,9 +29,7 @@ module.exports = {
         }).catch(e => {
             const s = e.toString().toLowerCase().split(` `)
 
-            res.send(`yeah, no`)
-
-            //res.status(s.includes(`found`) ? 404 : 500).send({ error: e });
+            res.status(s.includes(`found`) ? 404 : 500).send({ error: e });
         })
     }
 }

--- a/src/middleware/verifySchema.js
+++ b/src/middleware/verifySchema.js
@@ -58,13 +58,14 @@ module.exports = (schema, schemaType) => (req, res, next) => {
             };
         } else if(!provided && match.default) {
             original = match.default;
+            req[schemaType][key] = match.default;
         }
 
         if(reasons.length > 0) {
             notMatching[key] = reasons.reduce((a,b) => Object.assign(a, b), {});
         }
 
-        req[schemaType][key] = original;
+        //req[schemaType][key] = original;
     };
 
     console.log(`verifySchema [${schemaType}]`, notMatching);

--- a/src/utils/leaderboard.js
+++ b/src/utils/leaderboard.js
@@ -264,7 +264,7 @@ module.exports = {
             }
         })*/
     }),
-    getRecent: ({ page, limit }) => new Promise(async (res, rej) => {
+    getRecent: ({ page, limit, id }) => new Promise(async (res, rej) => {
         Models.leaderboards.aggregate([ // please forgive me for this shit oh my god
             {
                 $project: {
@@ -322,6 +322,11 @@ module.exports = {
             {
                 $unwind: '$scores'
             },
+            (id && {
+                $match: {
+                    'scores.id': id
+                }
+            } || {}),
             {
                 $sort: {
                     'scores.timeSet': -1

--- a/src/utils/removeArrayDuplicates.js
+++ b/src/utils/removeArrayDuplicates.js
@@ -1,0 +1,1 @@
+module.exports = (arr) => arr.filter((a, b) => arr.indexOf(a) === b);


### PR DESCRIPTION
previously, the api retrieved all values and sorted everything by itself, which would be problematic once hundreds (or mayb thousands) of scores were to be submitted

now we pin that pain to mongodb's servers >:3

(additional: `/leaderboard/recent` endpoint for website use to show recent scores site-wide or for a specific user)